### PR TITLE
Clarify calling `checkResponse()` again

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ element.dispatchEvent(event);
 // If `respondWith()` is not called, `checkResponse()`
 // function will callback with `undefined`.
 event.checkResponse();
-
-const token = await authenticate.promise;
 ```
 
 In the hosting page, the following code snippet responds with a token.
@@ -53,6 +51,7 @@ To reduce code complexity, the `checkResponse()` function guarantees the `callba
 
 - If `respondWith()` was called, `checkResponse()` will return `true`.
 - If `respondWith()` was never called, `checkResponse()` will call the `callback` function with `undefined`, and return `false`.
+   - Subsequent calls to `checkResponse()` will return `true`.
 
 It is recommended to put `checkResponse()` immediately after `dispatchEvent()`.
 

--- a/packages/respondable-event/src/RespondableEvent.spec.ts
+++ b/packages/respondable-event/src/RespondableEvent.spec.ts
@@ -126,6 +126,18 @@ describe('when respondWith() is not called', () => {
       test('once', () => expect(callback).toHaveBeenCalledTimes(1));
       test('with undefined', () => expect(callback).toHaveBeenNthCalledWith(1, undefined, event));
     });
+
+    describe('when checkResponse() is called again', () => {
+      let checkResponseAgainReturnValue: boolean;
+
+      beforeEach(() => {
+        checkResponseAgainReturnValue = event.checkResponse();
+      });
+
+      it('should return true', () => expect(checkResponseAgainReturnValue).toBe(true));
+
+      test('callback should be called once', () => expect(callback).toHaveBeenCalledTimes(1));
+    });
   });
 });
 


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

(No changelog for non-production code change.)

## Specific changes

> Please list each individual specific change in this pull request.

- Clarified calling `checkResponse()` again
- Added a test case